### PR TITLE
Another way to build trivial-gamekit-based applications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 *.sx32fsl
 *.wx64fsl
 *.wx32fsl
+build/

--- a/Makefile
+++ b/Makefile
@@ -12,4 +12,10 @@ buildapp: main.lisp
 		--output ld42.bin
 
 clean:
-	rm -rf ld42.bin quicklisp-manifest.txt
+	rm -rf ld42.bin quicklisp-manifest.txt build
+
+
+dist: main.lisp
+	sbcl --eval "(ql:quickload '(trivial-gamekit/distribution ld42))" \
+	     --eval "(gamekit.distribution:deliver :ld42 'cl-user::example)" \
+	     --quit

--- a/ld42.asd
+++ b/ld42.asd
@@ -1,0 +1,4 @@
+(asdf:defsystem :ld42
+  :serial t
+  :depends-on (trivial-gamekit)
+  :components ((:file "main")))


### PR DESCRIPTION
Just an example of how to use `trivial-gamekit/distribution` facility.

To build, invoke:
```bash
make clean dist
```